### PR TITLE
Fix border still visible in fullscreen mode

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -196,9 +196,11 @@ video {
   border-radius: 6px;
   margin: 20px auto;
   max-width: 100%;
-  border: 1px solid var(--border-color);
   aspect-ratio: 16 / 9;
   height: auto !important;
+}
+.plyr:not(:fullscreen) {
+  border: 1px solid var(--border-color);
 }
 .plyr video {
   object-fit: contain;


### PR DESCRIPTION
The border around the in-page player is still displayed on the edges of the screen when in fullscreen mode, which is pretty distracting on OLED-screen phones and other "edge-less" devices.

This makes the border conditional, not displaying it when the player is in fullscreen mode.